### PR TITLE
Cygwin support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,5 @@
 ---
 metatrader_setup_url: https://download.mql5.com/cdn/web/metaquotes.software.corp/mt5/mt5setup.exe
 metatrader_version: 5
+is_unix: "{{ ansible_os_family != 'Windows' and not ansible_os_family.startswith('CYGWIN') }}"
+platform_name: "{{ 'Windows' if ansible_os_family == 'Windows' else 'Cygwin' if ansible_os_family.startswith('CYGWIN') else ansible_os_family }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -10,8 +10,8 @@ roles:
   - name: ea31337.wine
     scm: git
     src: git+https://github.com/EA31337/ansible-role-wine.git
-    version: 0e40694bddb81a914e2d80dfd6e08877b359b477
+    version: 468fc6e4307e0e2c63ac7b06562d83e83fa9f023
   - name: ea31337.xvfb
     scm: git
     src: git+https://github.com/EA31337/ansible-role-xvfb.git
-    version: 8581fe7ef41691588992a200f8dcb5122b6e813b
+    version: 6bf9c85423fc48ae4c01158eb0ba64fe767dec4b

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,56 +4,268 @@
     filter:
       - ansible_local
   when: false
+
+- name: Populate paths
+  ansible.builtin.include_tasks: paths.yml
+  tags:
+    - metatrader_paths
+
 - name: Checks if platform is already exist
   ansible.builtin.stat:
     path: "{{ ansible_local['metatrader'][metatrader_version | string].path }}"
   register: stat_mt
-  when: ansible_local['metatrader'] is defined
+  when: ansible_local['metatrader'] is defined and ansible_local['metatrader'][metatrader_version | string].path is defined
+
 - name: Ensures platform is installed
   when:
     - ansible_local['metatrader'] is not defined
     - ansible_os_family != "Windows"  # gather_facts is required.
     - (stat_mt.stat is not defined) or (not stat_mt.stat.exists)
   block:
-
     - name: Validates variables
       ansible.builtin.assert:
         that:
           - metatrader_setup_url | length > 0
 
-    - name: Checks if platform is already installed
-      register: file_mt_installed_exists
+    - name: Checks if platform is already installed (Unix)
+      register: file_mt_installed_exists_result
       ansible.builtin.stat:
         path: ~/.wine/.installed-mt{{ metatrader_version }}
       when:
-        - ansible_os_family != "Windows"
+        - is_unix
 
-    - name: Ensures verb installation file is present
+    - set_fact: file_mt_installed_exists="{{file_mt_installed_exists_result}}"
+      when: (file_mt_installed_exists_result.stat is defined) and (file_mt_installed_exists_result.stat.exists)
+
+    - name: Checks if platform is already installed (Windows)
+      register: file_mt_installed_exists_result
+      win_stat:
+        path: C:\Temp\.installed-mt{{ metatrader_version }}
+      when:
+        - platform_name == "Windows"
+
+    - set_fact: file_mt_installed_exists="{{file_mt_installed_exists_result}}"
+      when: (file_mt_installed_exists_result.stat is defined) and (file_mt_installed_exists_result.stat.exists)
+
+    - name: Checks if platform is already installed (Cygwin)
+      register: file_mt_installed_exists_result
+      win_stat:
+        path: /tmp/.installed-mt{{ metatrader_version }}
+      when:
+        - platform_name == "Cygwin"
+
+    - set_fact: file_mt_installed_exists="{{file_mt_installed_exists_result}}"
+      when: (file_mt_installed_exists_result.stat is defined) and (file_mt_installed_exists_result.stat.exists)
+
+    - name: Ensures Curl is present (Excluding Cygwin)
+      ansible.builtin.package:
+        name: curl
+        state: present
+      when:
+        - is_unix
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
+
+    - name: Ensures verb installation file is present (Unix)
       ansible.builtin.template:
         src: mt{{ metatrader_version }}_install.verb.j2
         dest: /tmp/mt{{ metatrader_version }}_install.verb
         mode: "0640"
       when:
-        - not file_mt_installed_exists.stat.exists
+        - is_unix
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
 
-    - name: Ensures MetaTrader is installed (via verb file)
+    - name: Ensure Temp directory exists (Windows)
+      win_file:
+        path: C:\Temp
+        state: directory
+      when:
+        - platform_name == "Windows"
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
+
+    - name: Ensures verb installation file is present (Cygwin)
+      ansible.builtin.template:
+        src: mt{{ metatrader_version }}_install.ahk.j2
+        dest: /tmp/mt{{ metatrader_version }}_install.ahk
+        mode: "0640"
+      when:
+        - platform_name == "Cygwin"
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
+
+    - name: Ensures verb installation file is present (Windows)
+      ansible.builtin.template:
+        src: mt{{ metatrader_version }}_install.ahk.j2
+        dest: C:\Temp\mt{{ metatrader_version }}_install.ahk
+        mode: "0640"
+      when:
+        - platform_name == "Windows"
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
+
+    - name: Ensures MetaTrader is installed (via verb file, Unix)
       ansible.builtin.shell:
         # noqa command-instead-of-shell
         cmd: >
           winetricks -q /tmp/mt{{ metatrader_version }}_install.verb
           && touch ~/.wine/.installed-mt{{ metatrader_version }}
         creates: ~/.wine/.installed-mt{{ metatrader_version }}
+      args:
+        executable: /bin/bash
       environment:
         DISPLAY: ":0"
         WINEDLLOVERRIDES: mscoree,mshtml=,winebrowser.exe=
         WINETRICKS_DOWNLOADER: curl
       when:
-        - not file_mt_installed_exists.stat.exists
+        - is_unix
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
 
-    - name: Ensures verb installation file is absent
+    # Installation via AutoHotkey.
+    - name: Download AutoHotkey installer (Cygwin)
+      get_url:
+        url: https://www.autohotkey.com/download/1.1/AutoHotkey_1.1.37.02.zip
+        dest: "{{ ansible_env.HOME }}/ahk-portable.zip"
+      when:
+        - platform_name == "Cygwin"
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
+
+    - name: Ensure {{ ansible_env.HOME }}/ahk-portable directory exists (Cygwin)
+      ansible.builtin.file:
+        path: "{{ ansible_env.HOME }}/ahk-portable"
+        state: directory
+      when:
+        - platform_name == "Cygwin"
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
+
+    - name: Ensure {{ ansible_env.HOME }}/ahk-portable/mt directory exists (Windows, Cygwin)
+      ansible.builtin.file:
+        path: "{{ ansible_env.HOME }}/ahk-portable/mt"
+        state: directory
+      when:
+        - platform_name == "Cygwin" or platform_name == "Windows"
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
+
+    - name: Downloading MetaTrader installer (Windows, Cygwin)
+      get_url:
+        url: "{{ metatrader_setup_url }}"
+        dest: "{{ ansible_env.HOME }}/ahk-portable/mt/setup.exe"
+      when:
+        - platform_name == "Cygwin" or platform_name == "Windows"
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
+
+    - name: Chmod MetaTrader installer to make it executable (Cygwin, Windows)
+      ansible.builtin.file:
+        path: "{{ ansible_env.HOME }}/ahk-portable/mt/setup.exe"
+        mode: "0755"
+      when:
+        - platform_name == "Cygwin" or platform_name == "Windows"
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
+
+    - name: Extract AutoHotkey (Cygwin)
+      ansible.builtin.unarchive:
+        src: "{{ ansible_env.HOME }}/ahk-portable.zip"
+        dest: "{{ ansible_env.HOME }}/ahk-portable"
+      when:
+        - platform_name == "Cygwin"
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
+        
+    - name: Download AutoHotkey installer (Windows)
+      win_get_url:
+        url: https://www.autohotkey.com/download/1.1/AutoHotkey_1.1.37.02.zip
+        src: "{{ ansible_env.HOME }}\\ahk-portable.zip"
+      when:
+        - platform_name == "Windows"
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
+
+    - name: Ensure {{ ansible_env.HOME }}\ahk-portable directory exists (Windows)
+      ansible.builtin.file:
+        path: "{{ ansible_env.HOME }}\\ahk-portable"
+        state: directory
+      when:
+        - platform_name == "Windows"
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
+
+    - name: Extract AutoHotkey (Windows)
+      community.windows.win_unzip:
+        src: "{{ ansible_env.HOME }}\\ahk-portable.zip"
+        dest: "{{ ansible_env.HOME }}\\ahk-portable"
+      when:
+        - platform_name == "Windows"
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
+
+    - name: Verify AutoHotkey is extracted (Cygwin)
+      ansible.builtin.stat:
+        path: "{{ ansible_env.HOME }}/ahk-portable/AutoHotkeyU64.exe"
+      register: ahk_stat_result
+      when: 
+        - platform_name == "Cygwin"
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
+
+    - set_fact: ahk_stat="{{ahk_stat_result}}"
+      when: (ahk_stat_result.stat is defined) and (ahk_stat_result.stat.exists)
+
+    - name: Verify AutoHotkey is installed (Windows)
+      win_stat:
+        path: "{{ ansible_env.HOME }}\\ahk-portable\\AutoHotkeyU64.exe"
+      register: ahk_stat_result
+      when: 
+        - (ahk_stat is not defined) or (ahk_stat.stat is not defined) or (not ahk_stat.stat.exists)
+        - platform_name == "Windows"
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
+
+    - set_fact: ahk_stat="{{ahk_stat_result}}"
+      when: (ahk_stat_result.stat is defined) and (ahk_stat_result.stat.exists)
+
+    - name: Fail if AutoHotkey is not installed (Cygwin, Windows)
+      fail:
+        msg: "AutoHotkey download/extraction failed!"
+      when:
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
+        - (ahk_stat.stat is not defined) or (not ahk_stat.stat.exists)
+        - (platform_name == "Cygwin" or platform_name == "Windows")
+
+    - name: Chmod AutoHotkey to make it executable (Cygwin, Windows)
+      ansible.builtin.file:
+        path: "{{ ansible_env.HOME }}/ahk-portable/AutoHotkeyU64.exe"
+        mode: "0755"
+      when:
+        - platform_name == "Cygwin" or platform_name == "Windows"
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
+
+    - name: Run installation with AutoHotkey (Cygwin)
+      shell:
+        cmd: >
+          '{{ ahk_stat.stat.path }} `cygpath -w /tmp/mt{{ metatrader_version }}_install.ahk`'
+          && touch /tmp/.installed-mt{{ metatrader_version }}
+        creates: '/tmp/.installed-mt{{ metatrader_version }}'
+      args:
+        executable: /bin/bash
+        chdir: "{{ ansible_env.HOME }}/ahk-portable/mt"
+      become: yes
+      become_method: runas
+      become_user: SYSTEM
+      when:
+        - platform_name == "Cygwin"
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
+
+    - name: Run installation with AutoHotkey (Windows)
+      win_shell:
+        cmd:
+          '{{ ahk_stat.stat.path }} C:\Temp\mt{{ metatrader_version }}_install.ahk; if ($?) { New-Item -Path "C:\Temp\.installed-mt{{ metatrader_version }}" -ItemType File -Force }'
+        creates: 'C:\Temp\.installed-mt{{ metatrader_version }}'
+      args:
+        executable: cmd
+        chdir: "{{ ansible_env.HOME }}/ahk-portable/mt"
+      become: yes
+      become_method: runas
+      become_user: SYSTEM
+      when:
+        - platform_name == "Windows"
+        - (file_mt_installed_exists is not defined) or (not file_mt_installed_exists.stat.exists)
+
+    - name: Ensures verb installation file is absent (Unix)
       ansible.builtin.file:
         path: /tmp/mt{{ metatrader_version }}_install.verb
         state: absent
+      when:
+        - is_unix
 
 - name: Verifies
   ansible.builtin.include_tasks: verify.yml
@@ -63,10 +275,10 @@
 - name: Saves platform facts
   become: true
   when:
-    - >-
-      ansible_local['metatrader'] is not defined
-      or (find_mt_path_folder)
-      != ansible_local['metatrader'][metatrader_version | string].path
+    - >
+      (ansible_local['metatrader'] is not defined) or 
+      (ansible_local['metatrader'][metatrader_version | string] is not defined) or 
+      (find_mt_path_folder != ansible_local['metatrader'][metatrader_version | string].path)
   block:
     - name: Sets fact
       ansible.builtin.set_fact:
@@ -82,12 +294,22 @@
         - find_mt_path_folder is defined
         - find_mt_path_folder | length > 0
         - metatrader_version is defined
+
     - name: Ensures that Ansible local facts directory exists (Unix)
       ansible.builtin.file:
         path: /etc/ansible/facts.d
         state: directory
         mode: "0755"
-      when: ansible_os_family != "Windows"
+      when: is_unix
+
+    - name: Ensures that Ansible local facts directory exists (Cygwin)
+      ansible.builtin.file:
+        path: /etc/ansible/facts.d
+        state: directory
+        mode: "0755"
+      become: false
+      when: is_unix or platform_name == "Cygwin"
+
     - name: Ensures that Ansible local facts directory exists (Windows)
       ansible.windows.win_file:
         # yamllint disable-line rule:line-length
@@ -96,13 +318,23 @@
       become: true
       become_method: ansible.builtin.runas
       become_user: "{{ ansible_env.USERNAME }}"
-      when: ansible_os_family == "Windows"
+      when: platform_name == "Windows"
+
     - name: Saves role's facts (Unix)
       ansible.builtin.copy:
         content: "{{ ansible_facts['metatrader'] }}"
         dest: /etc/ansible/facts.d/metatrader.fact
         mode: "0644"
-      when: ansible_os_family != "Windows"
+      when: is_unix
+
+    - name: Saves role's facts (Cygwin)
+      ansible.builtin.copy:
+        content: "{{ ansible_facts['metatrader'] }}"
+        dest: /etc/ansible/facts.d/metatrader.fact
+        mode: "0644"
+      become: false
+      when: platform_name == "Cygwin"
+
     - name: Saves role's facts (Windows)
       ansible.windows.win_copy:
         content: "{{ ansible_facts['metatrader'] }}"
@@ -111,4 +343,4 @@
       become: true
       become_method: ansible.builtin.runas
       become_user: "{{ ansible_env.USERNAME }}"
-      when: ansible_os_family == "Windows"
+      when: platform_name == "Windows"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,52 +10,22 @@
   tags:
     - metatrader_paths
 
-- name: Checks if platform is already exist
+- name: Checks if platform already exist
   ansible.builtin.stat:
-    path: "{{ ansible_local['metatrader'][metatrader_version | string].path }}"
+    path: "{{ mt_runner_mt_path_host }}"
   register: stat_mt
-  when: ansible_local['metatrader'] is defined and ansible_local['metatrader'][metatrader_version | string].path is defined
 
 - name: Ensures platform is installed
   when:
-    - ansible_local['metatrader'] is not defined
-    - ansible_os_family != "Windows"  # gather_facts is required.
+    - (ansible_local['metatrader'] is not defined)
+      or (ansible_local['metatrader'][metatrader_version | string] is not defined)
+      or (ansible_local['metatrader'][metatrader_version | string].path == '')
     - (stat_mt.stat is not defined) or (not stat_mt.stat.exists)
   block:
     - name: Validates variables
       ansible.builtin.assert:
         that:
           - metatrader_setup_url | length > 0
-
-    - name: Checks if platform is already installed (Unix)
-      register: file_mt_installed_exists_result
-      ansible.builtin.stat:
-        path: ~/.wine/.installed-mt{{ metatrader_version }}
-      when:
-        - is_unix
-
-    - set_fact: file_mt_installed_exists="{{file_mt_installed_exists_result}}"
-      when: (file_mt_installed_exists_result.stat is defined) and (file_mt_installed_exists_result.stat.exists)
-
-    - name: Checks if platform is already installed (Windows)
-      register: file_mt_installed_exists_result
-      win_stat:
-        path: C:\Temp\.installed-mt{{ metatrader_version }}
-      when:
-        - platform_name == "Windows"
-
-    - set_fact: file_mt_installed_exists="{{file_mt_installed_exists_result}}"
-      when: (file_mt_installed_exists_result.stat is defined) and (file_mt_installed_exists_result.stat.exists)
-
-    - name: Checks if platform is already installed (Cygwin)
-      register: file_mt_installed_exists_result
-      win_stat:
-        path: /tmp/.installed-mt{{ metatrader_version }}
-      when:
-        - platform_name == "Cygwin"
-
-    - set_fact: file_mt_installed_exists="{{file_mt_installed_exists_result}}"
-      when: (file_mt_installed_exists_result.stat is defined) and (file_mt_installed_exists_result.stat.exists)
 
     - name: Ensures Curl is present (Excluding Cygwin)
       ansible.builtin.package:
@@ -105,8 +75,6 @@
         # noqa command-instead-of-shell
         cmd: >
           winetricks -q /tmp/mt{{ metatrader_version }}_install.verb
-          && touch ~/.wine/.installed-mt{{ metatrader_version }}
-        creates: ~/.wine/.installed-mt{{ metatrader_version }}
       args:
         executable: /bin/bash
       environment:
@@ -231,10 +199,7 @@
 
     - name: Run installation with AutoHotkey (Cygwin)
       shell:
-        cmd: >
-          '{{ ahk_stat.stat.path }} `cygpath -w /tmp/mt{{ metatrader_version }}_install.ahk`'
-          && touch /tmp/.installed-mt{{ metatrader_version }}
-        creates: '/tmp/.installed-mt{{ metatrader_version }}'
+        cmd: "{{ ahk_stat.stat.path }} \"$(cygpath -w /tmp/mt{{ metatrader_version }}_install.ahk)\""
       args:
         executable: /bin/bash
         chdir: "{{ ansible_env.HOME }}/ahk-portable/mt"
@@ -248,8 +213,7 @@
     - name: Run installation with AutoHotkey (Windows)
       win_shell:
         cmd:
-          '{{ ahk_stat.stat.path }} C:\Temp\mt{{ metatrader_version }}_install.ahk; if ($?) { New-Item -Path "C:\Temp\.installed-mt{{ metatrader_version }}" -ItemType File -Force }'
-        creates: 'C:\Temp\.installed-mt{{ metatrader_version }}'
+          '{{ ahk_stat.stat.path }} C:\Temp\mt{{ metatrader_version }}_install.ahk'
       args:
         executable: cmd
         chdir: "{{ ansible_env.HOME }}/ahk-portable/mt"
@@ -320,7 +284,7 @@
       become_user: "{{ ansible_env.USERNAME }}"
       when: platform_name == "Windows"
 
-    - name: Saves role's facts (Unix)
+    - name: Saves role's facts (Unix, Cygwin)
       ansible.builtin.copy:
         content: "{{ ansible_facts['metatrader'] }}"
         dest: /etc/ansible/facts.d/metatrader.fact

--- a/tasks/paths.yml
+++ b/tasks/paths.yml
@@ -1,0 +1,70 @@
+---
+- name: Set platform's client OS directory path (MT4) - Windows-style path under Wine
+  ansible.builtin.set_fact:
+    mt_runner_mt_path_wine: C:\Program Files (x86)\MetaTrader 4
+    mt_runner_mt_terminal_path_wine: 'C:\Program Files (x86)\MetaTrader 4\terminal.exe'
+  when: (mt_runner_mt_version | int) == 4
+
+- name: Set platform's client OS directory path (MT5) - Windows-style path under Wine
+  ansible.builtin.set_fact:
+    mt_runner_mt_path_wine: C:\Program Files\MetaTrader 5
+    mt_runner_mt_terminal_path_wine: 'C:\Program Files\MetaTrader 5\terminal64.exe'
+  when: (mt_runner_mt_version | int) == 5
+
+- name: Set wine_prefix variable
+  ansible.builtin.set_fact:
+    wine_prefix: '{{ ansible_env.WINEPREFIX | default(ansible_env.HOME + "/.wine") }}'
+
+- name: Set platform's host OS directory path (MT4) - Windows-style path, later converted to Unix if needed
+  ansible.builtin.set_fact:
+    mt_runner_mt_path_windows: C:\Program Files (x86)\MetaTrader 4
+    mt_runner_mt_path_cygwin: /cygdrive/c/Program Files (x86)/MetaTrader 4
+    mt_runner_mt_path_unix: '{{ wine_prefix }}/drive_c/Program Files (x86)/MetaTrader 4'
+    mt_runner_mt_terminal_path_windows: 'C:\Program Files (x86)\MetaTrader 4\terminal.exe'
+    mt_runner_mt_terminal_path_cygwin: '/cygdrive/c/Program Files (x86)/MetaTrader 4/terminal.exe'
+    mt_runner_mt_terminal_path_unix: '{{ wine_prefix }}/drive_c/Program Files (x86)/MetaTrader 4/terminal.exe'
+  when: (mt_runner_mt_version | int) == 4
+
+- name: Set platform's host OS directory path (MT5) - Windows-style path, later converted to Unix if needed
+  ansible.builtin.set_fact:
+    mt_runner_mt_path_windows: C:\Program Files\MetaTrader 5
+    mt_runner_mt_path_cygwin: /cygdrive/c/Program Files/MetaTrader 5
+    mt_runner_mt_path_unix: '{{ wine_prefix }}/drive_c/Program Files/MetaTrader 5'
+    mt_runner_mt_terminal_path_windows: 'C:\Program Files\MetaTrader 5\terminal64.exe'
+    mt_runner_mt_terminal_path_cygwin: '/cygdrive/c/Program Files/MetaTrader 5/terminal64.exe'
+    mt_runner_mt_terminal_path_unix: '{{ wine_prefix }}/drive_c/Program Files/MetaTrader 5/terminal64.exe'
+  when: (mt_runner_mt_version | int) == 5
+
+- name: Pick the right path for the platform (Windows)
+  ansible.builtin.set_fact:
+    mt_runner_mt_path_host: '{{ mt_runner_mt_path_windows }}'
+    mt_runner_mt_terminal_path_host: '{{ mt_runner_mt_terminal_path_windows }}'
+  when: platform_name == "Windows"
+
+- name: Pick the right path for the platform (Cygwin)
+  ansible.builtin.set_fact:
+    mt_runner_mt_path_host: '{{ mt_runner_mt_path_cygwin }}'
+    mt_runner_mt_terminal_path_host: '{{ mt_runner_mt_terminal_path_cygwin }}'
+  when: platform_name == "Cygwin"
+
+- name: Pick the right path for the platform (Unix)
+  ansible.builtin.set_fact:
+    mt_runner_mt_path_host: '{{ mt_runner_mt_path_unix }}'
+    mt_runner_mt_terminal_path_host: '{{ mt_runner_mt_terminal_path_unix }}'
+  when: is_unix
+
+- name: Print platform paths
+  ansible.builtin.debug:
+    msg: >-
+      PLATFORM:
+      mt_runner_mt_path_host: {{ mt_runner_mt_path_host }},
+      mt_runner_mt_path_windows: {{ mt_runner_mt_path_windows }},
+      mt_runner_mt_path_cygwin: {{ mt_runner_mt_path_cygwin }},
+      mt_runner_mt_path_unix: {{ mt_runner_mt_path_unix }},
+      mt_runner_mt_path_wine: {{ mt_runner_mt_path_wine }},
+      TERMINAL:
+      mt_runner_mt_terminal_path_host: {{ mt_runner_mt_terminal_path_host }}
+      mt_runner_mt_terminal_path_windows: {{ mt_runner_mt_terminal_path_windows }},
+      mt_runner_mt_terminal_path_cygwin: {{ mt_runner_mt_terminal_path_cygwin }},
+      mt_runner_mt_terminal_path_unix: {{ mt_runner_mt_terminal_path_unix }},
+      mt_runner_mt_terminal_path_wine: {{ mt_runner_mt_terminal_path_wine }},

--- a/tasks/verify.yml
+++ b/tasks/verify.yml
@@ -3,33 +3,37 @@
   tags:
     - metatrader_verify
   block:
+    - name: Populate paths
+      ansible.builtin.include_tasks: paths.yml
+      tags:
+        - metatrader_paths
     - name: Checks if platform's terminal exists (Unix)
       changed_when: false
       failed_when: find_mt_res.matched == 0
       ansible.builtin.find:
-        paths: "{{ ansible_env.HOME }}/.wine/drive_c"
+        paths: '{{ mt_runner_mt_path_unix }}'
         patterns: terminal*.exe
         recurse: true
       register: find_mt_res
-      when: ansible_os_family != "Windows"
+      when: is_unix
 
     - name: Store platform's path (Unix)
       ansible.builtin.set_fact:
         find_mt_path: '"{{ find_mt_res.files[0].path }}"'
         find_mt_path_folder: "{{ find_mt_res.files[0].path | dirname }}"
       when:
-        - ansible_os_family != "Windows"
+        - is_unix
         - find_mt_res.files | length > 0
 
     - name: Checks if platform's terminal exists (Windows)
       changed_when: false
       failed_when: find_mt_res.matched == 0
       ansible.windows.win_find:
-        paths: C:/Program Files/MetaTrader 5
+        paths: '{{ mt_runner_mt_path }}'
         patterns: terminal*.exe
         recurse: true
       register: find_mt_res
-      when: ansible_os_family == "Windows"
+      when: platform_name == "Windows"
 
     - name: Store platform's path (Windows)
       ansible.builtin.set_fact:
@@ -39,40 +43,80 @@
         - ansible_os_family == "Windows"
         - find_mt_res.files | length > 0
 
+    - name: Checks if platform's terminal exists (Cygwin)
+      changed_when: false
+      failed_when: find_mt_res.matched == 0
+      ansible.builtin.find:
+        paths: '{{ mt_runner_mt_path_cygwin }}'
+        patterns: terminal*.exe
+        recurse: true
+      register: find_mt_res
+      when: platform_name == "Cygwin"
+
+    - name: Store platform's path (Cygwin)
+      ansible.builtin.set_fact:
+        find_mt_path: '"{{ find_mt_res.files[0].path }}"'
+        find_mt_path_folder: "{{ find_mt_res.files[0].path | dirname }}"
+      when:
+        - platform_name == "Cygwin"
+        - find_mt_res.files | length > 0
+
     - name: Checks if platform's editor exists (Unix)
       changed_when: false
       failed_when: find_mte_res.matched == 0
       ansible.builtin.find:
-        paths: "{{ ansible_env.HOME }}/.wine/drive_c"
+        paths: '{{ mt_runner_mt_path_unix }}'
         patterns: "[mM]eta[eE]ditor*.exe"
         recurse: true
       register: find_mte_res
-      when: ansible_os_family != "Windows"
+      when: is_unix
 
     - name: Store platform's editor path (Unix)
       ansible.builtin.set_fact:
         find_mte_path: "{{ find_mte_res.files[0].path }}"
         find_mte_path_folder: "{{ find_mte_res.files[0].path | dirname }}"
       when:
-        - ansible_os_family != "Windows"
+        - is_unix
         - find_mte_res.files | length > 0
 
     - name: Checks if platform's editor exists (Windows)
       changed_when: false
       failed_when: find_mte_res.matched == 0
       ansible.windows.win_find:
-        paths: C:/Program Files/MetaTrader 5
+        paths:
+          - C:/Program Files/MetaTrader 5
+          - C:/Program Files (x86)/MetaTrader 4
         patterns: "[mM]eta[eE]ditor*.exe"
         recurse: true
       register: find_mte_res
-      when: ansible_os_family == "Windows"
+      when: platform_name == "Windows"
 
     - name: Store platform's editor path (Windows)
       ansible.builtin.set_fact:
         find_mte_path: "{{ find_mte_res.files[0].path }}"
         find_mte_path_folder: "{{ find_mte_res.files[0].path | win_dirname }}"
       when:
-        - ansible_os_family == "Windows"
+        - platform_name == "Windows"
+        - find_mte_res.files | length > 0
+
+    - name: Checks if platform's editor exists (Cygwin)
+      changed_when: false
+      failed_when: find_mte_res.matched == 0
+      ansible.builtin.find:
+        paths:
+          - /cygdrive/c/Program Files/MetaTrader 5          
+          - /cygdrive/c/Program Files (x86)/MetaTrader 4
+        patterns: "[mM]eta[eE]ditor*.exe"
+        recurse: true
+      register: find_mte_res
+      when: platform_name == "Cygwin"
+
+    - name: Store platform's editor path (Cygwin)
+      ansible.builtin.set_fact:
+        find_mte_path: "{{ find_mte_res.files[0].path }}"
+        find_mte_path_folder: "{{ find_mte_res.files[0].path | dirname }}"
+      when:
+        - platform_name == "Cygwin"
         - find_mte_res.files | length > 0
 
     - name: Check WSL's default distribution name (Windows)
@@ -83,23 +127,23 @@
           wsl -l -v | Select-String -Pattern '\*'
           | ForEach-Object { ($_ -split '\s+')[1] }
       register: wsl_distribution_name_result
-      when: ansible_os_family == "Windows"
+      when: platform_name == "Windows"
 
     - name: Store WSL's default distribution name (Windows)
       ansible.builtin.set_fact:
         wsl_distribution_name: >-
           {{ wsl_distribution_name_result.output[0]
           | regex_replace("\u0000", "") }}
-      when: ansible_os_family == "Windows"
+      when: platform_name == "Windows"
 
     - name: Check WSL's default user name (Windows)
       changed_when: false
       failed_when: not wsl_user_name_result
       ansible.windows.win_command: ubuntu -c "whoami"
       register: wsl_user_name_result
-      when: ansible_os_family == "Windows"
+      when: platform_name == "Windows"
 
     - name: Store WSL's default user name (Windows)
       ansible.builtin.set_fact:
         wsl_user_name: "{{ wsl_user_name_result.stdout_lines[0] }}"
-      when: ansible_os_family == "Windows"
+      when: platform_name == "Windows"

--- a/templates/mt4_install.ahk.j2
+++ b/templates/mt4_install.ahk.j2
@@ -1,0 +1,57 @@
+; Maximum time for setup to complete.
+Timeout := 600000 ; 10 min.
+
+; Searching for a setup's EXE file.
+loop, Files, *.exe
+{
+    ExePath := A_LoopFileFullPath
+    break
+}
+
+; Running setup.
+Run, %ExePath%
+SetTitleMatchMode, RegEx
+
+; Awaiting for setup window to appear.
+WinWait, 4 Setup,, 30
+
+; Clicking "Next".
+Send, !n
+
+StartTime := A_TickCount
+
+loop
+{
+    ; Check if timout have passed.
+    if (A_TickCount - StartTime > Timeout)
+    {
+        break
+    }
+
+    ; Is "Finish" button visible?
+    ControlGet, FinishVisible, Visible,, Finish
+
+    if (FinishVisible)
+    {
+        break
+    }
+
+    ; Sleeping for a short while before checking again.
+    Sleep, 1000
+}
+
+; Clicking "Finish".
+Send, {Enter}
+
+; Awaiting for terminal process and window to appear.
+Process, Wait, terminal.exe, 5
+WinWaitActive, ahk_class MetaQuotes::MetaTrader::4.00
+
+; Closing dialogs and exiting from the terminal.
+Send, {Esc}, {Esc}, !fx, !{F4} ; File->Exit, Alt-F4
+
+; Awaiting terminal window to close for 2s.
+WinWaitClose, ahk_exe terminal.exe, 2
+
+; If terminal didn't close in 2s then we're forcing it to close.
+Process, Close, terminal.exe

--- a/templates/mt4_install.verb.j2
+++ b/templates/mt4_install.verb.j2
@@ -15,7 +15,7 @@ load_mt4_install()
     fi
 
     # Opens a webpage.
-    WINEDLLOVERRIDES="winebrowser.exe="
+    WINEDLLOVERRIDES="mshtml=,winebrowser.exe="
     export WINEDLLOVERRIDES
 
     # No documented silent install option, unfortunately.

--- a/templates/mt5_install.ahk.j2
+++ b/templates/mt5_install.ahk.j2
@@ -1,0 +1,56 @@
+; Maximum time for setup to complete.
+Timeout := 600000 ; 10 min.
+
+; Searching for a setup's EXE file.
+loop, Files, *.exe
+{
+    ExePath := A_LoopFileFullPath
+    break
+}
+
+; Running setup.
+Run, %ExePath%
+SetTitleMatchMode, RegEx
+
+; Awaiting for setup window to appear.
+WinWait, MetaTrader 5,, 30
+
+; Clicking "Next".
+Send, !n
+
+StartTime := A_TickCount
+
+loop
+{
+    ; Check if timout have passed.
+    if (A_TickCount - StartTime > Timeout)
+    {
+        break
+    }
+
+    ; Is "Finish" button visible?
+    ControlGet, FinishVisible, Visible,, Finish
+
+    if (FinishVisible)
+    {
+        break
+    }
+
+    ; Sleeping for a short while before checking again.
+    Sleep, 1000
+}
+
+; Clicking "Finish".
+Send, {Enter}
+
+; Awaiting for terminal process and window to appear.
+Process, Wait, terminal.exe, 5
+
+; Closing dialogs and exiting from the terminal.
+Send, {Esc}, {Esc}, !fx, !{F4} ; File->Exit, Alt-F4
+
+; Awaiting terminal window to close for 2s.
+WinWaitClose, ahk_exe terminal64.exe, 2
+
+; If terminal didn't close in 2s then we're forcing it to close.
+Process, Close, terminal64.exe

--- a/templates/mt5_install.verb.j2
+++ b/templates/mt5_install.verb.j2
@@ -14,7 +14,7 @@ load_mt5_install()
       w_call opensymbol
     fi
 
-    WINEDLLOVERRIDES="winebrowser.exe="
+    WINEDLLOVERRIDES="mshtml=,winebrowser.exe="
     export WINEDLLOVERRIDES
 
     w_try_cd "$W_CACHE/$W_PACKAGE"


### PR DESCRIPTION
## Summary by Sourcery

Add support for Cygwin platform in MetaTrader installation process, extending the existing installation workflow to handle Cygwin-specific requirements

New Features:
- Add comprehensive Cygwin platform support for MetaTrader installation

Enhancements:
- Refactor installation tasks to support multiple platforms (Windows, Unix, Cygwin)
- Introduce dynamic path resolution for different operating systems
- Add AutoHotkey-based installation method for Cygwin and Windows

Chores:
- Update role dependencies
- Modify default variables to detect platform type